### PR TITLE
Fix whitespace

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -279,11 +279,11 @@ function genFragment(
   // Base Case
   if (nodeName === '#text') {
     let text = node.textContent;
-    if (text.trim() === '' && inBlock === null) {
+    if (!options.retainWhitespace && text.trim() === '' && inBlock === null) {
       return getEmptyChunk();
     }
 
-    if (text.trim() === '' && inBlock !== 'code-block') {
+    if (!options.retainWhitespace && text.trim() === '' && inBlock !== 'code-block') {
       return getWhitespaceChunk(inEntity);
     }
     if (inBlock !== 'code-block') {
@@ -493,10 +493,12 @@ function getChunkForHTML(
   options,
   DOMBuilder
 ) {
-  html = html
-    .trim()
-    .replace(REGEX_CR, '')
-    .replace(REGEX_NBSP, SPACE);
+  if (!options.retainWhitespace) {
+    html = html
+      .trim()
+      .replace(REGEX_CR, '')
+      .replace(REGEX_NBSP, SPACE);
+  }
 
   const safeBody = DOMBuilder(html);
   if (!safeBody) {
@@ -621,7 +623,8 @@ const convertFromHTML = ({
 }) => (
   html,
   options = {
-    flat: false
+    flat: false,
+    retainWhitespace: false
   },
   DOMBuilder = getSafeBodyFromHTML
 ) => {

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -594,20 +594,34 @@ describe('convertFromHTML', () => {
     expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
   });
 
-  it('maintains leading and trailing whitespace with retainWhitespace option', () => {
+  it('maintains leading and trailing whitespace with retainWhitespace option (Issue 79)', () => {
     const html = '<span>  simple whitespace test </span>';
     const contentState = toContentState(html, { retainWhitespace: true });
     expect(contentState.getBlocksAsArray().length).toBe(1);
     expect(contentState.getBlocksAsArray()[0].getText()).toBe('  simple whitespace test ');
   });
 
-  it('maintains whitespace before, after, and between other tags with retainWhitespace option', () => {
+  it('maintains whitespace before, after, and between other tags with retainWhitespace option (Issue 79)', () => {
     const html = '<span>  <b>tags</b> and whitespace </br> </br> <i>test</i>  </span>';
     const contentState = toContentState(html, { retainWhitespace: true });
     expect(contentState.getBlocksAsArray().length).toBe(3);
     expect(contentState.getBlocksAsArray()[0].getText()).toBe('  tags and whitespace ');
     expect(contentState.getBlocksAsArray()[1].getText()).toBe(' ');
     expect(contentState.getBlocksAsArray()[2].getText()).toBe(' test  ');
+  });
+
+  it('maintains non-breaking "between tags" whitespaces with retainWhitespace option (Issue 79)', () => {
+    const html = '<p>    <b>Bold Text</b>    </p>';
+    const contentState = toContentState(html, { retainWhitespace: true });
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('    Bold Text    ');
+  });
+
+  it('consolidates multiple "between tags" whitespaces without retainWhitespace option (Issue 79)', () => {
+    const html = '<p>    <b>Bold Text</b>    </p>';
+    const contentState = toContentState(html, { retainWhitespace: false });
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe(' Bold Text ');
   });
 
   it('still maintains simple case leading and trailing whitespace without retainWhitespace option', () => {

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -593,4 +593,38 @@ describe('convertFromHTML', () => {
     expect(contentState.getBlocksAsArray().length).toBe(1);
     expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
   });
+
+  it('maintains leading and trailing whitespace with retainWhitespace option', () => {
+    const html = '<span>  simple whitespace test </span>';
+    const contentState = toContentState(html, { retainWhitespace: true });
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('  simple whitespace test ');
+  });
+
+  it('maintains whitespace before, after, and between other tags with retainWhitespace option', () => {
+    const html = '<span>  <b>tags</b> and whitespace </br> </br> <i>test</i>  </span>';
+    const contentState = toContentState(html, { retainWhitespace: true });
+    expect(contentState.getBlocksAsArray().length).toBe(3);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('  tags and whitespace ');
+    expect(contentState.getBlocksAsArray()[1].getText()).toBe(' ');
+    expect(contentState.getBlocksAsArray()[2].getText()).toBe(' test  ');
+  });
+
+  it('still maintains simple case leading and trailing whitespace without retainWhitespace option', () => {
+    // default behavior keeps whitespace when HTML tags do not delineate it
+    const html = '<span>  simple whitespace test </span>';
+    const contentState = toContentState(html);
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('  simple whitespace test ');
+  });
+
+  it('collapses whitespace before, after, and between other tags without retainWhitespace option', () => {
+    // default behavior collapses whitespace when HTML tags delineate it
+    const html = '<span>  <b>tags</b> and whitespace </br> </br> <i>test</i>  <u>stuff</u> </span>';
+    const contentState = toContentState(html);
+    expect(contentState.getBlocksAsArray().length).toBe(3);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('tags and whitespace ');
+    expect(contentState.getBlocksAsArray()[1].getText()).toBe('');
+    expect(contentState.getBlocksAsArray()[2].getText()).toBe('teststuff');
+  });
 });

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -220,6 +220,13 @@ describe('convertFromHTML', () => {
     expect(convertToHTML(contentState)).toBe('<p>one<br/>two</p>');
   });
 
+  it('DOESNT convert br tag to block boundaries with four items', () => {
+    const html = '<p>one<br/>two<br/>three<br/>four</p>';
+    const contentState = toContentState(html);
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(convertToHTML(contentState)).toBe('<p>one<br/>two<br/>three<br/>four</p>');
+  });
+
   it('converts multiple consecutive brs', () => {
     const html = '<p>one<br/><br/>two</p>';
     const contentState = toContentState(html);
@@ -380,6 +387,14 @@ describe('convertFromHTML', () => {
     blocks.forEach(block => {
       expect(block.getType()).toBe('unstyled');
     });
+  });
+
+  it('unescapes HTML encoded characters in text and converts them back', () => {
+    const html = '<p>test&amp;</p>';
+    const contentState = toContentState(html);
+    expect(contentState.getPlainText()).toBe('test&');
+    const resultHTML = convertToHTML(contentState);
+    expect(resultHTML).toBe(html);
   });
 
   it('handles nested blocks in blockquote', () => {


### PR DESCRIPTION
Extracted from https://github.com/HubSpot/draft-convert/pull/93, fixes issue where whitespace surrounding links or formatted text is sometimes being stripped. 